### PR TITLE
Fix useEffectOnce re-initialization after real cleanup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,12 @@ function useEffectOnce(effect, useEffectFn = useEffect) {
       // if the comp didn't render since the useEffect was called,
       // we know it's the dummy React cycle
       if (!renderAfterCalled.current) return;
+
+      // reset refs after teardown so a reused fiber re-initializes on remount
       if (destroyFunc.current) destroyFunc.current();
+      destroyFunc.current = undefined;
+      effectCalled.current = false;
+      renderAfterCalled.current = false;
     };
   }, []);
 }


### PR DESCRIPTION
## Problem

When a kapsule-wrapped component is unmounted and React later reuses the same hook state/refs on a remount-like path (e.g. browser back/forward navigation in the Next.js App Router), the component is never re-initialized.

`useEffectOnce` keeps `effectCalled`/`renderAfterCalled` set to `true` after the cleanup runs. On the next setup, the guard `if (!effectCalled.current)` is false, so `effect()` (which mounts the kapsule via `comp(domEl.current)`) is skipped. The canvas/DOM may still be visible, but the underlying controls/renderer/listeners are gone, so interactions (drag, zoom, click) are dead.

Refs vasturiano/react-force-graph#596.

## Fix

Reset the internal lifecycle refs after the destructor runs, so a subsequent setup re-initializes the component. The existing guard that skips React Strict Mode's development-only dummy cleanup is preserved, so dev behavior is unchanged.

## How to test

Reproduces in any setup where React reuses hook state across cleanup → setup:

- **React `<Activity>`**: render the wrapped component inside `<Activity mode="visible">`, switch to `"hidden"` (the destructor runs while the fiber/refs are preserved), then back to `"visible"`. Before this change the kapsule init does not run again; after, it does.
- **Real-world**: a Next.js App Router page rendering the component, navigated away from and returned to via browser back/forward — interactions keep working after the change.

The existing `example/strict-mode-example.html` still behaves correctly: `destroy` is logged exactly once on unmount and never on the Strict Mode dummy cleanup.
